### PR TITLE
changed counter to work with typst 0.1.0

### DIFF
--- a/leipzig-gloss.typ
+++ b/leipzig-gloss.typ
@@ -88,6 +88,10 @@
         }
     }
 
+    if numbering {
+        gloss_count.step()
+    }
+    
     let gloss_number = if numbering {
         [(#gloss_count.display())]
     } else {
@@ -95,10 +99,6 @@
     }
 
     [#gloss_number #pad(left: 1em)[#gloss_items]]
-
-    if numbering {
-        gloss_count.step()
-    }
 }
 
 #let numbered_gloss = gloss.with(numbering: true)


### PR DESCRIPTION
Typst 0.1.0 changes counters to start at 0 by default, so I moved the counter increment so that gloss numbering still starts at 1 as expected.