### PR TITLE
Add reference capability

### DIFF
--- a/documentation.typ
+++ b/documentation.typ
@@ -179,6 +179,20 @@ standard Typst counter functions to control gloss numbering:
     translation: [There always is in us a will for a great happiness.],
 )", addl-bindings: (gloss-count: gloss-count))
 
+References to individual examples can be achieved using the `label` argument and the referencing mechanism of Typst:
+
+#codeblock(
+"See @sorcerers:
+
+#numbered-gloss(
+    header: [Middle Welsh; modified from _Grammatical number in Welsh_ (1999) by Silva Nurmio (§~2.1.1)],
+    source: ([ac], [ny], [allvs], [y], [dewinyon], [atteb], [idav]),
+		morphemes: ([and], [#neg], [be_able.#smallcaps[pret].3#sg], [#smallcaps[def]], [sorcerer.#pl], [answer.#smallcaps[inf]], [to.3#sg.#smallcaps[m]]),
+    translation: [and the sorcerers could not answer him],
+		label: \"sorcerers\",
+)
+
+As we have seen in @sorcerers, […].", addl-bindings: (neg: neg, sg: sg, pl: pl))
 
 == Styling lines of a gloss
 

--- a/leipzig-gloss.typ
+++ b/leipzig-gloss.typ
@@ -1,6 +1,7 @@
 #import "abbreviations.typ"
 
 #let gloss-count = counter("gloss_count")
+#let cmdlabel = label // a workround so we can use `label` as a variable name
 
 #let build_gloss(item-spacing, formatters, gloss_line_lists) = {
     assert(gloss_line_lists.len() > 0, message: "Gloss line lists cannot be empty")
@@ -47,6 +48,7 @@
     additional-lines: (), //List of list of content
     translation: none,
     translation-style: none,
+    label: none,
 
     item-spacing: 1em,
     gloss-padding: 2.0em, //TODO document these
@@ -121,13 +123,18 @@
 
     style(styles => {
         block(breakable: breakable)[
-            #stack(
-            dir:ltr, //TODO this needs to be more flexible
-            left_padding,
-            [#gloss_number],
-            gloss-padding - left_padding - measure([#gloss_number],styles).width,
-            [#gloss_items]
-            )
+            #figure(
+                kind: "lingexample",
+                supplement: [Example],
+                numbering: it => [#gloss-count.display()],
+                stack(
+                    dir: ltr, //TODO this needs to be more flexible
+                    left_padding,
+                    [#gloss_number],
+                    gloss-padding - left_padding - measure([#gloss_number],styles).width,
+                    align(left)[#gloss_items],
+                ),
+            ) #if label != none {cmdlabel(label)}
         ]
     }
     )


### PR DESCRIPTION
This adds a new argument, `label`, and makes use of the referencing mechanism of Typst. Mentioned in <https://github.com/neunenak/typst-leipzig-glossing/issues/4#issuecomment-2171900437>. I hope I will manage to solve #4 in the near future, including the ability to reference sub-examples (such as ‘Example 3b’). I’m new to Typst, so this might prove tricky for me.

In order to be able to use `label` as an argument, I had to make an alias (`cmdlabel`) to the original command. I suppose there is a better way to achieve that, without ugly workarounds.

Thank you for making and maintaining this package 🌼
I look forward to the time when Typst is on par with LaTeX and this package with ExPex 😃

