### PR TITLE
Subexample numbering customization

### DIFF
--- a/leipzig-gloss.typ
+++ b/leipzig-gloss.typ
@@ -4,6 +4,8 @@
 // │ Interlinear glosses │
 // ╰─────────────────────╯
 
+#let gen-number = numbering
+
 #let build-gloss(item-spacing, formatters, gloss-line-lists) = {
     assert(gloss-line-lists.len() > 0, message: "Gloss line lists cannot be empty")
 
@@ -121,6 +123,7 @@
     left-padding: 0.5em,
     numbering: false,
     breakable: false,
+    sub-num-pattern: "(a)",
     ..args
 ) = {
     let add-subexample(subexample, count) = {
@@ -142,7 +145,7 @@
                     supplement: it => {if "label-supplement" in subexample {return subexample.label-supplement} else {return "example"}},
                     stack(
                         dir: ltr, //TODO this needs to be more flexible
-                        [(#context count.display("a"))],
+                        [#context count.display(sub-num-pattern)],
                         left-padding,
                         gloss(..subexample-internal)
                     )

--- a/leipzig-gloss.typ
+++ b/leipzig-gloss.typ
@@ -123,6 +123,7 @@
     left-padding: 0.5em,
     numbering: false,
     breakable: false,
+    num-pattern: "(1)",
     sub-num-pattern: "(a)",
     ..args
 ) = {
@@ -159,7 +160,7 @@
     }
 
     let example-number = if numbering {
-        [(#context example-count.display())]
+        [#context example-count.display(num-pattern)]
     } else {
         none
     }

--- a/leipzig-gloss.typ
+++ b/leipzig-gloss.typ
@@ -4,8 +4,6 @@
 // │ Interlinear glosses │
 // ╰─────────────────────╯
 
-#let gen-number = numbering
-
 #let build-gloss(item-spacing, formatters, gloss-line-lists) = {
     assert(gloss-line-lists.len() > 0, message: "Gloss line lists cannot be empty")
 


### PR DESCRIPTION
Anyway, this addresses #8 by adding a [numbering](https://typst.app/docs/reference/model/numbering/) pattern argument `sub-num-pattern` to `example`. Now,

```
#numbered-example(
    sub-num-pattern: "a.",
    (
        source: ([subexample one],)
    ),
    (
        source: ([subexample two],)
    )
)
```

outputs
![image](https://github.com/user-attachments/assets/710f1c57-1484-437d-b5de-fc5f59551704)

Update: also adds `num-pattern`, which functions analogously, but for top-level examples.