### PR TITLE
left judge mark support

### DIFF
--- a/leipzig-gloss.typ
+++ b/leipzig-gloss.typ
@@ -42,6 +42,7 @@
   header-style: none,
   source: (),
   source-style: none,
+  judge: none,
   transliteration: none,
   transliteration-style: none,
   morphemes: none,
@@ -72,8 +73,11 @@
       linebreak()
     }
 
+    let judge-width = measure(judge).width
+    let source-judge = ([#h(-judge-width)#judge#source.at(0)],) + source.slice(1) // prepend judge to the first word
+
     let formatters = (source-style,)
-    let gloss-line-lists = (source,)
+    let gloss-line-lists = (source-judge,)
 
     if transliteration != none {
       formatters.push(transliteration-style)


### PR DESCRIPTION
this adds the `judge` argument, which mirrors expex's `\ljudge`: adds a mark (*, #, OK etc) to the left of `source` without shifting it to the right.

e.g.
```
#numbered-example(
  (
    source: ([это], [предложение], [плòхо]),
    judge: "*",
    morphemes: ([this], [sentence], [bad-#smallcaps[adv]]),
    translation: [Intended: This sentence is bad.],
  ),
  (
    source: ([это], [предложение], [плохò]),
    judge: [#super[OK]],
    morphemes: ([this], [sentence], [bad-#smallcaps[sadj]]),
    translation: [This sentence is bad.],
  ),
)
```
with increased left margin, it produces the following:
![image](https://github.com/user-attachments/assets/490e1cef-5605-4801-a0b7-ec74c8401cf5)
